### PR TITLE
Update salt options in documentation

### DIFF
--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -46,11 +46,10 @@ masterless setup.
 
 ## Install Options
 
-
 * `install_master`  (boolean) - Should vagrant install the salt-master
 on this machine. Not supported on Windows.
 
-* `no_minion`  (boolean) - Don't install the minion, default `false`
+* `no_minion`  (boolean) - Don't install the minion, default `false`. Not supported on Windows.
 
 * `install_syndic`   (boolean) - Install the salt-syndic, default
 `false`. Not supported on Windows.
@@ -65,10 +64,12 @@ you can specify a branch, tag, or any treeish. Not supported on Windows.
 * `always_install`   (boolean) - Installs salt binaries even
  if they are already detected, default `false`
 
-* `bootstrap_script` (string) - Path to your customized salt-bootstrap.sh script.
+* `bootstrap_script` (string) - Path to your customized salt-bootstrap.sh script. Not supported on Windows.
 
 * `bootstrap_options` (string) - Additional command-line options to
   pass to the bootstrap script.
+
+* `version`  (string, default: "2015.5.2") - Version of minion to be installed. Only supported on Windows.
 
 ## Minion Options
 These only make sense when `no_minion` is `false`.
@@ -78,20 +79,24 @@ a custom salt minion config file.
 
 * `minion_key`  (string) - Path to your minion key
 
+* `minion_id`  (string) - Unique identifier for minion. Used for masterless and preseeding keys.
+
 * `minion_pub`  (salt/key/minion.pub) - Path to your minion
 public key
 
 * `grains_config`  (string) - Path to a custom salt grains file.
 
+* `masterless`  (boolean) - Calls state.highstate in local mode. Uses `minion_id` and `pillar_data` when provided.
+
 ## Master Options
-These only make sense when `install_master` is `true`.
+These only make sense when `install_master` is `true`. Not supported on Windows.
 
 * `master_config` (string, default: "salt/master")
-  Path to a custom salt master config file
+  Path to a custom salt master config file.
 
-* `master_key` (salt/key/master.pem) - Path to your master key
+* `master_key` (salt/key/master.pem) - Path to your master key.
 
-* `master_pub` (salt/key/master.pub) - Path to your master public key
+* `master_pub` (salt/key/master.pub) - Path to your master public key.
 
 * `seed_master`  (dictionary) - Upload keys to master, thereby
 pre-seeding it before use. Example: `{minion_name:/path/to/key.pub}`
@@ -103,8 +108,16 @@ during provisioning.
 
 * `run_highstate` - (boolean) Executes `state.highstate` on
 vagrant up. Can be applied to any machine.
+
+## Execute Runners
+
+Either of the following may be used to actually execute runners
+during provisioning.
+
 * `run_overstate` - (boolean) Executes `state.over` on
-vagrant up. Can be applied to the master only.
+vagrant up. Can be applied to the master only. This is superceded by orchestrate. Not supported on Windows.
+* `orchestrations` - (boolean) Executes `state.orchestrate` on
+vagrant up. Can be applied to the master only. This is supercedes by run_overstate. Not supported on Windows.
 
 ## Output Control
 
@@ -114,7 +127,7 @@ These may be used to control the output of state execution:
 
 * `log_level` (string) - The verbosity of the outputs. Defaults to "debug".
   Can be one of "all", "garbage", "trace", "debug", "info", or
-  "warning".
+  "warning". Requires `verbose` to be set to "true".
 
 ## Pillar Data
 
@@ -148,7 +161,7 @@ times. The data passed in should only be hashes and lists. Here is an example::
 
 ## Preseeding Keys
 
-Preseeding keys is the recommended way to handle provisiong
+Preseeding keys is the recommended way to handle provisioning
 using a master.
 On a machine with salt installed, run
 `salt-key --gen-keys=[minion_id]` to generate the necessary


### PR DESCRIPTION
* Added details about what works for windows and what doesn't
* Broke runners and states out into separate sections
* Added 3 options: version, masterless, and minion_id
* Noted verbose is required for log level option to work
* Fixed minor typo