### PR TITLE
Changed minion config path for windows

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -113,7 +113,7 @@ module VagrantPlugins
 
         # FIXME: there should be a way to do that a bit smarter
         if guest_type == :windows
-          return "C:\\salt"
+          return "C:\\salt\\conf"
         else
           return "/etc/salt"
         end


### PR DESCRIPTION
Copy of minion is wrong on windows. Moved to sub-dir, conf.